### PR TITLE
Add logging on failing to delete node

### DIFF
--- a/lib/nerve/reporter/zookeeper.rb
+++ b/lib/nerve/reporter/zookeeper.rb
@@ -130,6 +130,8 @@ class Nerve::Reporter
           @zk.delete(@full_key, :ignore => :no_node)
         end
         @full_key = nil
+      else
+        log.error "Failed to delete node at: #{@zk_path} because we don't have the full_path."
       end
     end
 


### PR DESCRIPTION
I think it's possible this can happen if we have to kill the thread
before we get the full_key back from ZK